### PR TITLE
Add Integrations page to Company Settings

### DIFF
--- a/app/controllers/admin/integrations_controller.rb
+++ b/app/controllers/admin/integrations_controller.rb
@@ -1,0 +1,14 @@
+class Admin::IntegrationsController < Admin::AdminController
+  before_action :set_menu_items
+
+  def show
+    @api_key = current_company.company_setting.api_key
+  end
+
+  private
+
+  def set_menu_items
+    @main_selected = :settings
+    @sub_nav_selected = :integrations
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,7 @@ class ApplicationController < ActionController::Base
   include ValidateCompanyExpiry
   include PrepareExceptionNotifier
   include AuthorizeAdminAccess
-
-  after_action :allow_iframe_from_intercom
-  skip_after_action :intercom_rails_auto_include
+  include IntercomIframe
 
   protected
 
@@ -18,10 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-
-  def allow_iframe_from_intercom
-    response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM https://intercom-sheets.com"
-  end
 
   def after_sign_in_path_for(resource)
     return request.env['omniauth.origin'] if request.env['omniauth.origin']

--- a/app/controllers/concerns/intercom_iframe.rb
+++ b/app/controllers/concerns/intercom_iframe.rb
@@ -1,0 +1,15 @@
+module IntercomIframe
+  extend ActiveSupport::Concern
+
+  included do
+    skip_after_action :intercom_rails_auto_include
+
+    before_action do
+      session[:hide_public_header] = true if params[:intercom_iframe]
+    end
+
+    after_action do
+      response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM https://intercom-sheets.com"
+    end
+  end
+end

--- a/app/models/company_setting.rb
+++ b/app/models/company_setting.rb
@@ -1,4 +1,13 @@
 class CompanySetting < ApplicationRecord
   belongs_to :company
   validates :intercom_workspace_id, uniqueness: true, allow_nil: true
+
+  before_create :generate_api_key
+
+  def generate_api_key
+    self.api_key = loop do
+      token = SecureRandom.hex(16)
+      break token unless self.class.exists?(api_key: token)
+    end
+  end
 end

--- a/app/views/admin/_settings_sub_nav.html.slim
+++ b/app/views/admin/_settings_sub_nav.html.slim
@@ -5,3 +5,6 @@
   a.item href=admin_billing_path class=("active" if @sub_nav_selected == :billing)
     i.credit.card.outline.icon
     | Billing
+  a.item href=admin_integrations_path class=("active" if @sub_nav_selected == :integrations)
+    i.cube.icon
+    | Integrations

--- a/app/views/admin/integrations/show.html.slim
+++ b/app/views/admin/integrations/show.html.slim
@@ -1,0 +1,16 @@
+.c-settings-grid
+  .c-left-pane.dark
+    = render partial: "admin/settings_sub_nav"
+
+  .c-full-pane
+    .ui.grid
+      .row
+        .sixteen.wide.column
+          h1.heading Integrations
+      
+      .row
+        .six.wide.column
+          .ui.form
+            .field
+              label API key
+              input type="text" disabled=true value=@api_key

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,8 @@ html
 
   body class="#{controller_name} #{action_name}"
     = render partial: "partials/flash_messages"
-    = render partial: "partials/public_header"
+    - unless session[:hide_public_header]
+      = render partial: "partials/public_header"
     .ui.container
       = yield
     = render partial: "partials/external_js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
 
     resources :users, only: [:index, :show, :edit, :update]
     resource :billing, only: [:show], controller: :billing
+    resource :integrations, only: [:show], controller: :integrations
 
     resources :companies, only: [:edit, :update]
   end

--- a/spec/models/company_setting_spec.rb
+++ b/spec/models/company_setting_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe CompanySetting, type: :model do
   describe "Validations" do
     it { should validate_uniqueness_of(:intercom_workspace_id) }
   end
+
+  describe "before create" do
+    let(:company) { create :company }
+    let!(:company_setting) { create :company_setting, company: company }
+
+    it "generates and stores api token" do
+      expect(company_setting.api_key).to_not be_nil
+    end
+  end
 end

--- a/spec/models/company_setting_spec.rb
+++ b/spec/models/company_setting_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CompanySetting, type: :model do
     let(:company) { create :company }
     let!(:company_setting) { create :company_setting, company: company }
 
-    it "generates and stores api token" do
+    it "generates and stores api key" do
       expect(company_setting.api_key).to_not be_nil
     end
   end


### PR DESCRIPTION
This PR adds an integrations page in the company settings section. The main thing it shows currently is the company's API key, which is auto-generated after the company is created (also added in this PR).

![image](https://user-images.githubusercontent.com/1835120/66329916-46109900-e927-11e9-8808-338f8740ed74.png)
