### PR TITLE
Fix - exclude private comments, account name in admin

### DIFF
--- a/app/javascript/store/RootReducer.js
+++ b/app/javascript/store/RootReducer.js
@@ -28,7 +28,7 @@ export default (state = initialState, action) => {
           if(state.selectedPost && post.id === action.post.id) {
             return ({
               ...post,
-              comments_count: action.post.comments.length,
+              comments_count: action.post.comments.filter(comment => !comment.private).length,
               votes_count: action.post.voters.length,
             });
           }

--- a/app/views/admin/posts/show.json.jbuilder
+++ b/app/views/admin/posts/show.json.jbuilder
@@ -50,7 +50,7 @@ json.voters do
     json.initials voter.initials
     json.role voter.membership_for(current_company).role
     json.job_title voter.job_title
-    json.company_name voter.membership_for(current_company).company.name
+    json.company_name (voter.account_for(current_company).name rescue "")
     json.deletable !voter.votes.where(post: @post).first.manual?
   end
 end


### PR DESCRIPTION
 - Exclude private comments in the post index
![image](https://user-images.githubusercontent.com/17567875/79137324-2378a480-7dd0-11ea-9995-57967d2ee3c9.png)

- Fix account name in admin post voters list
![image](https://user-images.githubusercontent.com/17567875/79137446-5f136e80-7dd0-11ea-9e11-b517a0818d3f.png)
