### PR TITLE
Fail safely when setting user.name to an empty string

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ApplicationRecord
   end
 
   def name=(name)
+    return unless name.present?
+
     self.first_name, self.last_name = name.split(" ")
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,10 +93,17 @@ RSpec.describe User, type: :model do
 
   describe User, "#name=" do
     it "sets the user's first_name and last_name" do
-      user = build(:user, name: "Jamie Lannister")
+      user = build(:user, first_name: "", last_name: "")
 
+      user.name = "Jamie Lannister"
       expect(user.first_name).to eq("Jamie")
       expect(user.last_name).to eq("Lannister")
+    end
+
+    it "fails safely when name is empty" do
+      user = build(:user)
+
+      expect { user.name = "" }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
A lead from intercom will not have a name

```
/home/rails/apps/cadet-app/releases/20211124144118/app/models/user.rb:69:in `name='
/home/rails/apps/cadet-app/releases/20211124144118/app/controllers/intercom_controller.rb:109:in `create_and_sign_in_user'
/home/rails/apps/cadet-app/releases/20211124144118/app/controllers/intercom_controller.rb:19:in `sheets'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.4.4/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.4.4/lib/abstract_controller/base.rb:194:in `process_action'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.4.4/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/actionpack-5.2.4.4/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.4.4/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/react-rails-2.4.7/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
/home/rails/apps/cadet-app/shared/bundle/ruby/2.4.0/gems/activesupport-5.2.4.4/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
```
